### PR TITLE
fix: load pnpm-setup-action globally

### DIFF
--- a/.github/actions/setup-node-pnpm/action.yml
+++ b/.github/actions/setup-node-pnpm/action.yml
@@ -3,9 +3,9 @@ description: 'Sets up NodeJS and pnpm and installs dependencies.'
 
 inputs:
   pnpm-version:
-    description: Version of pnpm to use. (Defaults to 'latest')
+    description: Version of pnpm to use. (Defaults to an empty string to use the version specified in package.json)
     required: false
-    default: latest
+    default: ''
 
 runs:
   using: 'composite'

--- a/.github/actions/setup-node-pnpm/action.yml
+++ b/.github/actions/setup-node-pnpm/action.yml
@@ -9,7 +9,7 @@ inputs:
 
 runs:
   using: 'composite'
-  steps:  
+  steps:
     - name: Checkout
       uses: actions/checkout@v6
 

--- a/.github/actions/setup-node-pnpm/action.yml
+++ b/.github/actions/setup-node-pnpm/action.yml
@@ -13,6 +13,9 @@ runs:
     - name: Checkout
       uses: actions/checkout@v6
 
+    - run: echo ${{ inputs.pnpm-version }}
+      shell: bash
+
     - name: Setup pnpm
       uses: pnpm/action-setup@v4
       with:

--- a/.github/actions/setup-node-pnpm/action.yml
+++ b/.github/actions/setup-node-pnpm/action.yml
@@ -1,5 +1,12 @@
 name: 'Setup NodeJS environment with pnpm.'
 description: 'Sets up NodeJS and pnpm and installs dependencies.'
+
+inputs:
+  pnpm-version:
+    description: Version of pnpm to use. (Defaults to 'latest')
+    required: false
+    default: latest
+
 runs:
   using: 'composite'
   steps:  
@@ -9,7 +16,7 @@ runs:
     - name: Setup pnpm
       uses: pnpm/action-setup@v4
       with:
-        package_json_file: ${{ github.workspace }}/package.json
+        version: ${{ inputs.pnpm-version }}
 
     - name: Setup NodeJS
       uses: actions/setup-node@v6

--- a/.github/actions/setup-node-pnpm/action.yml
+++ b/.github/actions/setup-node-pnpm/action.yml
@@ -2,7 +2,10 @@ name: 'Setup NodeJS environment with pnpm.'
 description: 'Sets up NodeJS and pnpm and installs dependencies.'
 runs:
   using: 'composite'
-  steps:
+  steps:  
+    - name: Checkout
+      uses: actions/checkout@v6
+
     - name: Setup pnpm
       uses: pnpm/action-setup@v4
 

--- a/.github/actions/setup-node-pnpm/action.yml
+++ b/.github/actions/setup-node-pnpm/action.yml
@@ -8,6 +8,8 @@ runs:
 
     - name: Setup pnpm
       uses: pnpm/action-setup@v4
+      with:
+        package_json_file: ${{ github.workspace }}/package.json
 
     - name: Setup NodeJS
       uses: actions/setup-node@v6

--- a/.github/actions/setup-node-pnpm/action.yml
+++ b/.github/actions/setup-node-pnpm/action.yml
@@ -13,9 +13,6 @@ runs:
     - name: Checkout
       uses: actions/checkout@v6
 
-    - run: echo ${{ inputs.pnpm-version }}
-      shell: bash
-
     - name: Setup pnpm
       uses: pnpm/action-setup@v4
       with:

--- a/.github/workflows/build-pnpm.yml
+++ b/.github/workflows/build-pnpm.yml
@@ -43,11 +43,8 @@ jobs:
     name: Build & Artifact
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-
       - name: Setup
-        uses: ./.github/actions/setup-node-pnpm
+        uses: ExampleWasTakenStudios/workflows/.github/actions/setup-node-pnpm@master
 
       - name: Build Project
         run: ${{ inputs.command }}

--- a/.github/workflows/build-pnpm.yml
+++ b/.github/workflows/build-pnpm.yml
@@ -44,7 +44,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Setup
-        uses: ExampleWasTakenStudios/workflows/.github/actions/setup-node-pnpm@master
+        uses: ExampleWasTakenStudios/workflows/.github/actions/setup-node-pnpm@fix/setup-action
 
       - name: Build Project
         run: ${{ inputs.command }}

--- a/.github/workflows/build-pnpm.yml
+++ b/.github/workflows/build-pnpm.yml
@@ -44,7 +44,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Setup
-        uses: ExampleWasTakenStudios/workflows/.github/actions/setup-node-pnpm@fix/setup-action
+        uses: ExampleWasTakenStudios/workflows/.github/actions/setup-node-pnpm@master
 
       - name: Build Project
         run: ${{ inputs.command }}

--- a/.github/workflows/test-eslint.yml
+++ b/.github/workflows/test-eslint.yml
@@ -13,9 +13,6 @@ jobs:
     name: Lint
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-
       - name: Setup
         uses: ./.github/actions/setup-node-pnpm
 

--- a/.github/workflows/test-prettier.yml
+++ b/.github/workflows/test-prettier.yml
@@ -13,9 +13,6 @@ jobs:
     name: Prettier
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-
       - name: Setup
         uses: ./.github/actions/setup-node-pnpm
 


### PR DESCRIPTION
previously the action was loaded through relative paths which made it inaccessible to external repositories